### PR TITLE
Fix Turso Twitter account name

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -145,7 +145,7 @@ const themeConfig = {
           },
           {
             label: 'Follow us on Twitter',
-            href: 'https://twitter.com/ChiselStrike',
+            href: 'https://twitter.com/tursodatabase',
           },
           {
             label: 'Schedule a Zoom',


### PR DESCRIPTION
We renamed the Twitter account to "@tursodatabase".