### PR TITLE
Fix copying commands in Getting Started tutorial

### DIFF
--- a/tutorials/get-started-turso-cli/step-01-installation.md
+++ b/tutorials/get-started-turso-cli/step-01-installation.md
@@ -19,7 +19,7 @@ There is a Homebrew formula available that’s installed with the following
 command:
 
 ```bash
-$ brew install chiselstrike/tap/turso
+brew install chiselstrike/tap/turso
 ```
 
 The formula includes an executable with autocompletion scripts for bash, fish,
@@ -31,7 +31,7 @@ If you don’t use Homebrew, run the following command to execute a shell script
 that installs the CLI:
 
 ```bash
-$ curl -sSfL https://get.tur.so/install.sh | bash
+curl -sSfL https://get.tur.so/install.sh | bash
 ```
 
 The CLI is installed in a directory called `.turso` in your home directory. The
@@ -43,5 +43,5 @@ start a new shell to see the change, or add it manually to the current shell.
 Run the following command to make sure the Turso CLI is in your PATH:
 
 ```bash
-$ turso --version
+turso --version
 ```

--- a/tutorials/get-started-turso-cli/step-02-sign-up.md
+++ b/tutorials/get-started-turso-cli/step-02-sign-up.md
@@ -15,7 +15,7 @@ A GitHub account is required to sign up using the Turso CLI. Start the process
 with the following command:
 
 ```bash
-$ turso auth signup
+turso auth signup
 ```
 
 The CLI launches your default browser and asks to log in with GitHub. The first

--- a/tutorials/get-started-turso-cli/step-03-create-database.md
+++ b/tutorials/get-started-turso-cli/step-03-create-database.md
@@ -16,7 +16,7 @@ location as suggested by your IP address.  To see all locations supported by
 Turso, run the following command:
 
 ```bash
-$ turso db locations
+turso db locations
 ```
 
 Your default location appears highlighted in the list.
@@ -24,7 +24,7 @@ Your default location appears highlighted in the list.
 To create a database using the default location with the name `my-db`:
 
 ```bash
-$ turso db create my-db
+turso db create my-db
 ```
 
 It takes a few moments to create the database, then generates output similar to
@@ -58,7 +58,7 @@ generated for you.
 As suggested by the output, you can view information about the database using:
 
 ```bash
-$ turso db show my-db
+turso db show my-db
 ```
 
 The output looks similar to the following:
@@ -89,7 +89,7 @@ To see a list of all logical databases associated with the account that's
 currently logged in:
 
 ```bash
-$ turso db list
+turso db list
 ```
 
 [location]: /concepts#location

--- a/tutorials/get-started-turso-cli/step-04-make-queries-with-shell.md
+++ b/tutorials/get-started-turso-cli/step-04-make-queries-with-shell.md
@@ -14,7 +14,7 @@ The output of `turso db create` in the last step shows a command to run to start
 an interactive shell:
 
 ```bash
-$ turso db shell my-db
+turso db shell my-db
 ```
 
 ```

--- a/tutorials/get-started-turso-cli/step-05-create-use-replica.md
+++ b/tutorials/get-started-turso-cli/step-05-create-use-replica.md
@@ -17,7 +17,7 @@ The CLI creates a [replica] of the database in a specified [location] with
 three-letter location code from the output of `turso db locations`:
 
 ```bash
-$ turso db replicate my-db nrt
+turso db replicate my-db nrt
 ```
 
 This generates output similar to the following:
@@ -67,7 +67,7 @@ generated one for it at the time it was created. You can find the names of all
 the replicas using the the following command:
 
 ```bash
-$ turso db show my-db
+turso db show my-db
 ```
 
 The output is similar to this:
@@ -89,7 +89,7 @@ named "sweeping-ultragirl". Use this command to destroy it (replacing the name
 of the replica with your own):
 
 ```bash
-$ turso db destroy my-db --instance sweeping-ultragirl
+turso db destroy my-db --instance sweeping-ultragirl
 ```
 ```
 Destroyed instance sweeping-ultragirl of database my-db.

--- a/tutorials/get-started-turso-cli/step-06-inspect-database-usage.md
+++ b/tutorials/get-started-turso-cli/step-06-inspect-database-usage.md
@@ -23,7 +23,7 @@ in how much data you can store, and how many databases you can have.
 You can check the usage using `turso db inspect`:
 
 ```bash
-$ turso db inspect my-db
+turso db inspect my-db
 ```
 
 The output looks similar to the following:

--- a/tutorials/get-started-turso-cli/step-07-destroy-logical-database.md
+++ b/tutorials/get-started-turso-cli/step-07-destroy-logical-database.md
@@ -13,7 +13,7 @@ The CLI can destroy the entire [logical database], including the [primary] and
 all of its [replicas] with the following command:
 
 ```bash
-$ turso db destroy my-db
+turso db destroy my-db
 ```
 
 This is a very dangerous command since it deletes all data in the database and

--- a/tutorials/get-started-turso-cli/step-08-log-out.md
+++ b/tutorials/get-started-turso-cli/step-08-log-out.md
@@ -13,7 +13,7 @@ keywords:
 To log out, use the following command:
 
 ```bash
-$ turso auth logout
+turso auth logout
 ```
 
 This removes the persisted authentication token you received from the last

--- a/tutorials/get-started-turso-cli/turso-cli-review.md
+++ b/tutorials/get-started-turso-cli/turso-cli-review.md
@@ -76,15 +76,15 @@ The CLI has help available.  The following command summarizes the top-level
 commands available:
 
 ```bash
-$ turso help
+turso help
 ```
 
 For each specific command, you can add the `--help` flag to get details on all
 the sub-commands and flags. For example:
 
 ```
-$ turso db --help
-$ turso db create --help
+turso db --help
+turso db create --help
 ```
 
 


### PR DESCRIPTION
Remove the trailing dollar sign so that copying a command with the copy button works as expected.